### PR TITLE
Update build file to replace outdated gradle command

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile (name: 'wikitudesdk', ext:'aar')
-    compile 'com.google.ar:core:1.19.0'
+    implementation (name: 'wikitudesdk', ext:'aar')
+    implementation 'com.google.ar:core:1.19.0'
 }
 
 repositories {


### PR DESCRIPTION
'compile' action is deprecated since Gradle 7.0.0
Plugin fails to compile as-is on current versions of Cordova